### PR TITLE
Load Issues fix

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0.txt
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0.txt
@@ -1,7 +1,8 @@
-## APIVersion: 100010
+## APIVersion: 100011
 ## Title: LibAddonMenu-2.0
 ## Version: 2.0 rVERSION_NUMBER
-## Author: Seerah
+## Author: Seerah, sirinsidiator, et al.
+## Contributors: votan, merlight, Garkin
 ## Description: A library to aid in the creation of option panels.
 
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -7,7 +7,10 @@
 local MAJOR, MINOR = "LibAddonMenu-2.0", VERSION_NUMBER
 local lam, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
 if not lam then return end	--the same or newer version of this lib is already loaded into memory
-
+if(LAMSettingsPanelCreated and not LAMCompatibilityWarning) then 
+	zo_callLater(function() d("An old version of LibAddonMenu with compatibility issues was detected. For more information search for LibAddonMenu on esoui.com") end, 1000) 
+	LAMCompatibilityWarning = true
+end
 
 --UPVALUES--
 local wm = WINDOW_MANAGER

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -169,6 +169,7 @@ local function ToggleAddonPanels(panel)	--called in OnShow of newly shown panel
 	cm:FireCallbacks("LAM-RefreshPanel", panel)
 end
 
+local Initialize
 
 --METHOD: REGISTER ADDON PANEL
 --registers your addon with LibAddonMenu and creates a panel
@@ -176,6 +177,7 @@ end
 --	addonID = "string"; unique ID which will be the global name of your panel
 --	panelData = table; data object for your panel - see controls\panel.lua
 function lam:RegisterAddonPanel(addonID, panelData)
+	if(not LAMSettingsPanelCreated) then Initialize() end
 	local panel = lamcc.panel(nil, panelData, addonID)	--addonID==global name of panel
 	panel:SetHidden(true)
 	panel:SetAnchor(TOPLEFT, LAMAddonPanelsMenu, TOPRIGHT, 10, 0)
@@ -334,6 +336,8 @@ end
 
 
 --INITIALIZING
-CreateAddonSettingsPanel()
-CreateAddonList()
+function Initialize()
+	CreateAddonSettingsPanel()
+	CreateAddonList()
+end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -374,12 +374,11 @@ end
 EVENT_MANAGER:RegisterForEvent(eventHandle, EVENT_PLAYER_ACTIVATED, OnActivated)
 
 function Initialize(addonID)
-	if(safeToInitialize) then
-		CreateAddonSettingsPanel()
-		CreateAddonList()
-		hasInitialized = true
-	else
+	if(not safeToInitialize) then
 		local msg = string.format("The panel with id '%s' was registered before addon loading has completed. This might break the AddOn Settings menu.", addonID)
 		PrintLater(msg)
 	end
+	CreateAddonSettingsPanel()
+	CreateAddonList()
+	hasInitialized = true
 end

--- a/info/changelog.txt
+++ b/info/changelog.txt
@@ -1,3 +1,12 @@
+2.0 r17
+- updated for changes in 100011
+- fixed OpenToPanel function
+- fixed possible error with combobox names
+- half width control no longer have a fixed height and instead scale automatically now
+- changed controls to no longer use top level windows
+- fixed problems with the loading order and added warning if an old version gets initialized first
+A big thank you to everyone who helped making these changes, especially votan, merlight and Garkin!
+
 2.0 r16
 - updated for changes in 100010
 - thanks to Garkin for alerting me of changes needed and for testing on the test server

--- a/info/description.txt
+++ b/info/description.txt
@@ -1,17 +1,21 @@
-[SIZE="3"][COLOR="Cyan"]sirinsidiator has offered to take over LAM-2.0 and LibStub. :)[/COLOR][/SIZE]
+Since I (sirinsidiator) have taken over development of LAM-2.0 I decided it will be in the best interest of everyone to make future development a group effort.
+With the consent of Seerah I have put LAM-2.0 under [URL=https://github.com/sirinsidiator/ESO-LibAddonMenu/blob/master/LICENSE]The Artistic License 2.0[/URL] and created a [URL=https://github.com/sirinsidiator/ESO-LibAddonMenu]github project[/URL] in order to make collaborations possible.
+I also want to thank everyone who participated in planning and realizing upcoming changes, especially votan, merlight and Garkin.
 
-If you came here because a message in chat told you so, then you might use an outdated addon that uses an older version of LAM-2.0 which won't be compatible with ESO update6.
-But don't panic. There are a few things you can do in order to get it to work again.
+[B][SIZE="3"]If you came here because a message in chat told you so,[/SIZE][/B]  
+then you are using an outdated addon that relies on an older version of LAM-2.0 which might not be compatible with ESO update 6. 
+But no need to panic. There are a few things you can do in order to get it to work again:
 [LIST=1]
-* Update your addons. Maybe the author already fixed the problem.
-* Try to fix it yourself. <!-- add link to guide on the github wiki -->
-* Ask for help in the comment section
+[*]Update your addons. Maybe the author already fixed the problem.
+[*]Try to find out which addon uses the outdated version and ask for help in the comment section.
+[*]Ask for help in our comment section.
+[*]Install LibAddonMenu-2.0 as a stand alone addon.
 [/LIST]
 
 LibAddonMenu-2.0 is now released!
 Your addons will continue to work under LAM-1.0, however that version of the library will no longer be receiving updates, and you will not receive any benefits of LAM-2.0.
 
-[COLOR="Wheat"][B]** NOTE:[/B] If you have already updated your addon's settings panel to LAM2, but are using a version earlier than r6, please update your copy of the lib in the addon.  This will avoid duplicate LAM entries in the game's Settings menu.  (This bug does not occur in revisions 6+.)[B]**[/B][/COLOR]
+[COLOR="Wheat"][B]** NOTE:[/B] If you are using a version of LAM-2.0 earlier than r17, please update your copy of the lib in the addon. This will avoid problems with loading future versions of LAM.[B]**[/B][/COLOR]
 
 
 LibAddonMenu-2.0 is a library to aid addon authors in creating a configuration GUI for their addons which is located in the game's Settings menu.  It supports the ability to have all of a user's addon options located in the same panel.
@@ -57,6 +61,6 @@ local LAM = LibStub("LibAddonMenu-2.0")
      --returns a reference to the library table[/highlight]
 
 
-[SIZE="3"]Please see the [URL="http://www.esoui.com/portal.php?&id=5&pageid=10"]LAM-2.0 page on my portal[/URL] for guides and docs, as well as a list of differences between LAM-1.0 and LAM-2.0
+[SIZE="3"]Please see the [URL="https://github.com/sirinsidiator/ESO-LibAddonMenu/wiki"]LAM-2.0 wiki on github[/URL] for guides and docs, as well as a list of differences between LAM-1.0 and LAM-2.0
 
-[URL="http://www.esoui.com/portal.php?&id=5&pageid=15"]Details on LAM2 data tables[/URL][/SIZE]
+[URL="https://github.com/sirinsidiator/ESO-LibAddonMenu/wiki/Details-on-LAM2-data-tables"]Details on LAM2 data tables[/URL][/SIZE]

--- a/info/description.txt
+++ b/info/description.txt
@@ -1,5 +1,13 @@
 [SIZE="3"][COLOR="Cyan"]sirinsidiator has offered to take over LAM-2.0 and LibStub. :)[/COLOR][/SIZE]
 
+If you came here because a message in chat told you so, then you might use an outdated addon that uses an older version of LAM-2.0 which won't be compatible with ESO update6.
+But don't panic. There are a few things you can do in order to get it to work again.
+[LIST=1]
+* Update your addons. Maybe the author already fixed the problem.
+* Try to fix it yourself. <!-- add link to guide on the github wiki -->
+* Ask for help in the comment section
+[/LIST]
+
 LibAddonMenu-2.0 is now released!
 Your addons will continue to work under LAM-1.0, however that version of the library will no longer be receiving updates, and you will not receive any benefits of LAM-2.0.
 

--- a/info/description.txt
+++ b/info/description.txt
@@ -9,7 +9,7 @@ But no need to panic. There are a few things you can do in order to get it to wo
 [*]Update your addons. Maybe the author already fixed the problem.
 [*]Try to find out which addon uses the outdated version and ask for help in the comment section.
 [*]Ask for help in our comment section.
-[*]Install LibAddonMenu-2.0 as a stand alone addon.
+[*]Replace LibAddonMenu-2.0 in all your addons with the newest version.
 [/LIST]
 
 LibAddonMenu-2.0 is now released!

--- a/info/info.txt
+++ b/info/info.txt
@@ -1,3 +1,3 @@
 title: LibAddonMenu
-version: 2.0 r16
-compatiblity: 1.1
+version: 2.0 r17
+compatiblity: 1.6


### PR DESCRIPTION
Fix for #2.
I did a few test with 3 addons that use r14, r16 and r17 and succeeded in adding a lazy initialization that will prevent exceptions in the future.
I also added a helpful warning message that tells users that an older version of lam was loaded and where they should look for help + some help text in the description.
It could need some additional testing and I still need to write a wiki page which outlines what users can do by themselves when the warning is shown.