### PR TITLE
LibStub: allow library minor version to have fractional part

### DIFF
--- a/LibAddonMenu-2.0/LibStub/LibStub.lua
+++ b/LibAddonMenu-2.0/LibStub/LibStub.lua
@@ -3,7 +3,7 @@
 -- LibStub developed for World of Warcraft by above members of the WowAce community.
 -- Ported to Elder Scrolls Online by Seerah
 
-local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 3  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
 local LibStub = _G[LIBSTUB_MAJOR]
 
 local strformat = string.format
@@ -14,7 +14,9 @@ if not LibStub or LibStub.minor < LIBSTUB_MINOR then
 	
 	function LibStub:NewLibrary(major, minor)
 		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
-		minor = assert(tonumber(zo_strmatch(minor, "%d+")), "Minor version must either be a number or contain a number.")
+		if type(minor) ~= "number" then
+			minor = assert(tonumber(zo_strmatch(minor, "%d+%.?%d*")), "Minor version must either be a number or contain a number.")
+		end
 		
 		local oldminor = self.minors[major]
 		if oldminor and oldminor >= minor then return nil end


### PR DESCRIPTION
I know this is not the best place to send a patch to LibStub, it's just the most convenient.

This is a small change to LibStub:NewLibrary so that it doesn't strip fractional part from `minor` version number.

It also avoids the `number -> string -> number` round-trip if the supplied argument already is a number.
Otherwise it must be a string and is scanned for a sequence of digits (as before), optionally followed by a period '.' and 0 or more additional digits (new).
