### PR TITLE
allow initially enabled controls to be refreshed

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
@@ -75,7 +75,7 @@ function LAMCreateControl.button(parent, buttonData, controlName)
 		control.warning.data = {tooltipText = buttonData.warning}
 	end
 
-	if buttonData.disabled then
+	if buttonData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
@@ -129,7 +129,7 @@ function LAMCreateControl.checkbox(parent, checkboxData, controlName)
 
 	control.data.tooltipText = LAM.util.GetTooltipText(checkboxData.tooltip)
 
-	if checkboxData.disabled then
+	if checkboxData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
@@ -95,7 +95,7 @@ function LAMCreateControl.colorpicker(parent, colorpickerData, controlName)
 
 	control.data.tooltipText = LAM.util.GetTooltipText(colorpickerData.tooltip)
 
-	if colorpickerData.disabled then
+	if colorpickerData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
@@ -114,7 +114,7 @@ function LAMCreateControl.dropdown(parent, dropdownData, controlName)
 		control.warning.data = {tooltipText = dropdownData.warning}
 	end
 
-	if dropdownData.disabled then
+	if dropdownData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
@@ -100,7 +100,7 @@ function LAMCreateControl.editbox(parent, editboxData, controlName)
 	editbox:SetHandler("OnMouseEnter", function() ZO_Options_OnMouseEnter(control) end)
 	editbox:SetHandler("OnMouseExit", function() ZO_Options_OnMouseExit(control) end)
 
-	if not editboxData.isMultiline then 
+	if not editboxData.isMultiline then
 		container:SetHeight(24)
 	else
 		local width = container:GetWidth()
@@ -121,7 +121,7 @@ function LAMCreateControl.editbox(parent, editboxData, controlName)
 		control.warning.data = {tooltipText = editboxData.warning}
 	end
 
-	if editboxData.disabled then
+	if editboxData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
@@ -32,7 +32,7 @@ LAM.util.GetIconPickerMenu = function()
 	if not iconPicker then
 		iconPicker = IconPickerMenu:New("LAMIconPicker")
 		local sceneFragment = LAM:GetAddonSettingsFragment()
-		ZO_PreHook(sceneFragment, "OnHidden", function() 
+		ZO_PreHook(sceneFragment, "OnHidden", function()
 			if not iconPicker.control:IsHidden() then
 				iconPicker:Clear()
 			end
@@ -420,7 +420,7 @@ function LAMCreateControl.iconpicker(parent, iconpickerData, controlName)
 		control.warning.data = {tooltipText = iconpickerData.warning}
 	end
 
-	if iconpickerData.disabled then
+	if iconpickerData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -142,7 +142,7 @@ function LAMCreateControl.slider(parent, sliderData, controlName)
 		control.warning.data = {tooltipText = sliderData.warning}
 	end
 
-	if sliderData.disabled then
+	if sliderData.disabled ~= nil then
 		control.UpdateDisabled = UpdateDisabled
 		control:UpdateDisabled()
 	end


### PR DESCRIPTION
Previously, controls initially enabled (controlData.disabled == false)
would not have their disabled status updated on refresh. This problem existed with all controls which were eligible to be disabled.