### PR TITLE
removed height constraints on description control

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -286,15 +286,18 @@ local TwinOptionsContainer_Index = 0
 local function TwinOptionsContainer(parent, leftWidget, rightWidget)
 	TwinOptionsContainer_Index = TwinOptionsContainer_Index + 1
 	local cParent = parent.scroll or parent
-	local panel = parent.panel or parent
+	local panel = parent.panel or cParent
 	local container = wm:CreateControl("$(parent)TwinContainer" .. tostring(TwinOptionsContainer_Index),
 										cParent, CT_CONTROL)
-	container:SetWidth(cParent:GetWidth())
 	container:SetResizeToFitDescendents(true)
-
 	container:SetAnchor(select(2, leftWidget:GetAnchor(0) ))
+
 	leftWidget:ClearAnchors()
 	leftWidget:SetAnchor(TOPLEFT, container, TOPLEFT)
+	rightWidget:SetAnchor(TOPLEFT, leftWidget, TOPRIGHT, 5, 0)
+
+	leftWidget:SetWidth( leftWidget:GetWidth() - 2.5 ) -- fixes bad alignment with 'full' controls
+	rightWidget:SetWidth( rightWidget:GetWidth() - 2.5 )
 
 	leftWidget:SetParent(container)
 	rightWidget:SetParent(container)
@@ -323,9 +326,7 @@ local function CreateOptionsControls(panel)
 					widget:SetAnchor(TOPLEFT)
 					anchorTarget = widget
 				elseif wasHalf and isHalf then -- when the previous widget was only half width and this one is too, we place it on the right side
-					widget:SetAnchor(TOPLEFT, anchorTarget, TOPRIGHT, 5 + (offsetX or 0), 0)
 					widget.lineControl = anchorTarget
-					offsetY = zo_max(0, widget:GetHeight() - anchorTarget:GetHeight()) -- we need to get the common height of both widgets to know where the next row starts
 					isHalf = false
 					offsetY = 0
 					anchorTarget = TwinOptionsContainer(parent, anchorTarget, widget)

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -282,6 +282,27 @@ function lam:OpenToPanel(panel)
 	end
 end
 
+local TwinOptionsContainer_Index = 0
+local function TwinOptionsContainer(parent, leftWidget, rightWidget)
+	TwinOptionsContainer_Index = TwinOptionsContainer_Index + 1
+	local cParent = parent.scroll or parent
+	local panel = parent.panel or parent
+	local container = wm:CreateControl("$(parent)TwinContainer" .. tostring(TwinOptionsContainer_Index),
+										cParent, CT_CONTROL)
+	container:SetWidth(cParent:GetWidth())
+	container:SetResizeToFitDescendents(true)
+
+	container:SetAnchor(select(2, leftWidget:GetAnchor(0) ))
+	leftWidget:ClearAnchors()
+	leftWidget:SetAnchor(TOPLEFT, container, TOPLEFT)
+
+	leftWidget:SetParent(container)
+	rightWidget:SetParent(container)
+
+	container.data = {type = "container"}
+	container.panel = panel
+	return container
+end
 
 --INTERNAL FUNCTION
 --creates controls when options panel is first shown
@@ -306,6 +327,8 @@ local function CreateOptionsControls(panel)
 					widget.lineControl = anchorTarget
 					offsetY = zo_max(0, widget:GetHeight() - anchorTarget:GetHeight()) -- we need to get the common height of both widgets to know where the next row starts
 					isHalf = false
+					
+					anchorTarget = TwinOptionsContainer(parent, anchorTarget, widget)
 				else -- otherwise we just put it below the previous one normally
 					widget:SetAnchor(TOPLEFT, anchorTarget, BOTTOMLEFT, 0, 15 + offsetY)
 					offsetY = 0

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -327,10 +327,10 @@ local function CreateOptionsControls(panel)
 					widget.lineControl = anchorTarget
 					offsetY = zo_max(0, widget:GetHeight() - anchorTarget:GetHeight()) -- we need to get the common height of both widgets to know where the next row starts
 					isHalf = false
-					
+					offsetY = 0
 					anchorTarget = TwinOptionsContainer(parent, anchorTarget, widget)
 				else -- otherwise we just put it below the previous one normally
-					widget:SetAnchor(TOPLEFT, anchorTarget, BOTTOMLEFT, 0, 15 + offsetY)
+					widget:SetAnchor(TOPLEFT, anchorTarget, BOTTOMLEFT, 0, 15)
 					offsetY = 0
 					anchorTarget = widget
 				end

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -21,7 +21,6 @@ local function UpdateValue(control)
 	control.desc:SetText(control.data.text)
 end
 
-local MIN_HEIGHT = 26
 function LAMCreateControl.description(parent, descriptionData, controlName)
 	local control = LAM.util.CreateBaseControl(parent, descriptionData, controlName)
 	local isHalfWidth = control.isHalfWidth
@@ -29,9 +28,9 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
 	control:SetResizeToFitDescendents(true)
 
 	if isHalfWidth then
-		control:SetDimensionConstraints(width / 2, MIN_HEIGHT, width / 2, MIN_HEIGHT * 4)
+		control:SetDimensionConstraints(width / 2, 0, width / 2, 0)
 	else
-		control:SetDimensionConstraints(width, MIN_HEIGHT, width, MIN_HEIGHT * 4)
+		control:SetDimensionConstraints(width, 0, width, 0)
 	end
 
 	control.desc = wm:CreateControl(nil, control, CT_LABEL)


### PR DESCRIPTION
`SetDimensionConstraints` can be passed `0` to set no min/max, that's all this change does.

some examples:
[keeptooltip.lua#24](http://esodata.uesp.net/current/src/ingame/map/keeptooltip.lua.html#24)
[championperks.lua#2222](http://esodata.uesp.net/current/src/ingame/championperks/championperks.lua.html#2222)

-Terrillyn