### PR TITLE
Fix tooltip mouse exit events for sliders and textures

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -96,7 +96,7 @@ function LAMCreateControl.slider(parent, sliderData, controlName)
     local maxValue = sliderData.max
     slider:SetMinMax(minValue, maxValue)
     slider:SetHandler("OnMouseEnter", function() ZO_Options_OnMouseEnter(control) end)
-    slider:SetHandler("OnMouseEnter", function() ZO_Options_OnMouseExit(control) end)
+    slider:SetHandler("OnMouseExit", function() ZO_Options_OnMouseExit(control) end)
 
     slider.bg = wm:CreateControl(nil, slider, CT_BACKDROP)
     local bg = slider.bg

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -18,7 +18,7 @@
     reference = "MyAddonSlider" -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 10
+local widgetVersion = 11
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("slider", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/texture.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/texture.lua
@@ -10,7 +10,7 @@
 
 --add texture coords support?
 
-local widgetVersion = 8
+local widgetVersion = 9
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("texture", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/texture.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/texture.lua
@@ -38,7 +38,7 @@ function LAMCreateControl.texture(parent, textureData, controlName)
         texture:SetMouseEnabled(true)
         texture.data = {tooltipText = LAM.util.GetStringFromValue(textureData.tooltip)}
         texture:SetHandler("OnMouseEnter", ZO_Options_OnMouseEnter)
-        texture:SetHandler("OnMouseEnter", ZO_Options_OnMouseExit)
+        texture:SetHandler("OnMouseExit", ZO_Options_OnMouseExit)
     end
 
     return control


### PR DESCRIPTION
Hey @sirinsidiator, I noticed that a couple widgets in LAM-2.0 had wired up the wrong mouse exit events for clearing tooltips.  Here's a fix.