### PR TITLE
Update warning tooltips during panel refresh.

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -160,6 +160,16 @@ local function ShowConfirmationDialog(title, body, callback)
     ZO_Dialogs_ShowDialog(LAM_CONFIRM_DIALOG)
 end
 
+local function UpdateWarning(control)
+    local warning = util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 util.GetTooltipText = GetStringFromValue -- deprecated, use util.GetStringFromValue instead
 util.GetStringFromValue = GetStringFromValue
 util.GetDefaultValue = GetDefaultValue
@@ -168,6 +178,7 @@ util.CreateLabelAndContainerControl = CreateLabelAndContainerControl
 util.RequestRefreshIfNeeded = RequestRefreshIfNeeded
 util.RegisterForRefreshIfNeeded = RegisterForRefreshIfNeeded
 util.ShowConfirmationDialog = ShowConfirmationDialog
+util.UpdateWarning = UpdateWarning
 
 local ADDON_DATA_TYPE = 1
 local RESELECTING_DURING_REBUILD = true

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
@@ -25,6 +25,16 @@ local function UpdateDisabled(control)
     control.button:SetEnabled(not disable)
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 --controlName is optional
 local MIN_HEIGHT = 28 -- default_button height
 local HALF_WIDTH_LINE_SPACING = 2
@@ -73,10 +83,11 @@ function LAMCreateControl.button(parent, buttonData, controlName)
         end
     end)
 
-    if buttonData.warning then
+    if buttonData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, button, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(buttonData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     if buttonData.disabled ~= nil then

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
@@ -11,7 +11,7 @@
     reference = "MyAddonButton", -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 10
+local widgetVersion = 11
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("button", widgetVersion) then return end
 
@@ -23,16 +23,6 @@ local function UpdateDisabled(control)
         disable = disable()
     end
     control.button:SetEnabled(not disable)
-end
-
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
-    end
 end
 
 --controlName is optional
@@ -86,7 +76,7 @@ function LAMCreateControl.button(parent, buttonData, controlName)
     if buttonData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, button, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
@@ -70,6 +70,16 @@ local function UpdateValue(control, forceDefault, value)
     ToggleCheckbox(control)
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 local function OnMouseEnter(control)
     ZO_Options_OnMouseEnter(control)
 
@@ -118,10 +128,11 @@ function LAMCreateControl.checkbox(parent, checkboxData, controlName)
     control.checkedText = GetString(SI_CHECK_BUTTON_ON):upper()
     control.uncheckedText = GetString(SI_CHECK_BUTTON_OFF):upper()
 
-    if checkboxData.warning then
+    if checkboxData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, checkbox, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(checkboxData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.data.tooltipText = LAM.util.GetStringFromValue(checkboxData.tooltip)

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
@@ -12,7 +12,7 @@
 } ]]
 
 
-local widgetVersion = 12
+local widgetVersion = 13
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("checkbox", widgetVersion) then return end
 
@@ -70,16 +70,6 @@ local function UpdateValue(control, forceDefault, value)
     ToggleCheckbox(control)
 end
 
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
-    end
-end
-
 local function OnMouseEnter(control)
     ZO_Options_OnMouseEnter(control)
 
@@ -131,7 +121,7 @@ function LAMCreateControl.checkbox(parent, checkboxData, controlName)
     if checkboxData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, checkbox, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
@@ -51,6 +51,16 @@ local function UpdateValue(control, forceDefault, valueR, valueG, valueB, valueA
     control.thumb:SetColor(valueR, valueG, valueB, valueA or 1)
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 function LAMCreateControl.colorpicker(parent, colorpickerData, controlName)
     local control = LAM.util.CreateLabelAndContainerControl(parent, colorpickerData, controlName)
 
@@ -82,10 +92,11 @@ function LAMCreateControl.colorpicker(parent, colorpickerData, controlName)
         end
     end)
 
-    if colorpickerData.warning then
+    if colorpickerData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, control.color, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(colorpickerData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.data.tooltipText = LAM.util.GetStringFromValue(colorpickerData.tooltip)

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
@@ -12,7 +12,7 @@
 } ]]
 
 
-local widgetVersion = 11
+local widgetVersion = 12
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("colorpicker", widgetVersion) then return end
 
@@ -51,16 +51,6 @@ local function UpdateValue(control, forceDefault, valueR, valueG, valueB, valueA
     control.thumb:SetColor(valueR, valueG, valueB, valueA or 1)
 end
 
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
-    end
-end
-
 function LAMCreateControl.colorpicker(parent, colorpickerData, controlName)
     local control = LAM.util.CreateLabelAndContainerControl(parent, colorpickerData, controlName)
 
@@ -95,7 +85,7 @@ function LAMCreateControl.colorpicker(parent, colorpickerData, controlName)
     if colorpickerData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, control.color, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
@@ -51,6 +51,16 @@ local function UpdateValue(control, forceDefault, value)
     end
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 local function DropdownCallback(control, choiceText, choice)
     choice.control:UpdateValue(false, choiceText)
 end
@@ -103,10 +113,11 @@ function LAMCreateControl.dropdown(parent, dropdownData, controlName)
         dropdown:SetSortOrder(sortOrder == "up" and ZO_SORT_ORDER_UP or ZO_SORT_ORDER_DOWN, sortType == "name" and ZO_SORT_BY_NAME or ZO_SORT_BY_NAME_NUMERIC)
     end
 
-    if dropdownData.warning then
+    if dropdownData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, combobox, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(dropdownData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.UpdateChoices = UpdateChoices

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
@@ -14,7 +14,7 @@
 } ]]
 
 
-local widgetVersion = 13
+local widgetVersion = 14
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("dropdown", widgetVersion) then return end
 
@@ -48,16 +48,6 @@ local function UpdateValue(control, forceDefault, value)
     else
         value = control.data.getFunc()
         control.dropdown:SetSelectedItem(value)
-    end
-end
-
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
     end
 end
 
@@ -116,7 +106,7 @@ function LAMCreateControl.dropdown(parent, dropdownData, controlName)
     if dropdownData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, combobox, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
@@ -54,6 +54,16 @@ local function UpdateValue(control, forceDefault, value)
     end
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 local MIN_HEIGHT = 24
 local HALF_WIDTH_LINE_SPACING = 2
 function LAMCreateControl.editbox(parent, editboxData, controlName)
@@ -130,14 +140,15 @@ function LAMCreateControl.editbox(parent, editboxData, controlName)
     editbox:SetAnchor(TOPLEFT, container, TOPLEFT, 2, 2)
     editbox:SetAnchor(BOTTOMRIGHT, container, BOTTOMRIGHT, -2, -2)
 
-    if editboxData.warning then
+    if editboxData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         if editboxData.isExtraWide then
             control.warning:SetAnchor(BOTTOMRIGHT, control.bg, TOPRIGHT, 2, 0)
         else
             control.warning:SetAnchor(TOPRIGHT, control.bg, TOPLEFT, -5, 0)
         end
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(editboxData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.UpdateValue = UpdateValue

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
@@ -14,7 +14,7 @@
 } ]]
 
 
-local widgetVersion = 12
+local widgetVersion = 13
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("editbox", widgetVersion) then return end
 
@@ -51,16 +51,6 @@ local function UpdateValue(control, forceDefault, value)
     else
         value = control.data.getFunc()
         control.editbox:SetText(value)
-    end
-end
-
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
     end
 end
 
@@ -147,7 +137,7 @@ function LAMCreateControl.editbox(parent, editboxData, controlName)
         else
             control.warning:SetAnchor(TOPRIGHT, control.bg, TOPLEFT, -5, 0)
         end
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
@@ -18,7 +18,7 @@
     reference = "MyAddonIconPicker" -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 6
+local widgetVersion = 7
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("iconpicker", widgetVersion) then return end
 
@@ -327,16 +327,6 @@ local function UpdateValue(control, forceDefault, value)
     end
 end
 
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
-    end
-end
-
 local MIN_HEIGHT = 26
 local HALF_WIDTH_LINE_SPACING = 2
 local function SetIconSize(control, size)
@@ -421,7 +411,7 @@ function LAMCreateControl.iconpicker(parent, iconpickerData, controlName)
     if iconpickerData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, control.container, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
@@ -327,6 +327,16 @@ local function UpdateValue(control, forceDefault, value)
     end
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 local MIN_HEIGHT = 26
 local HALF_WIDTH_LINE_SPACING = 2
 local function SetIconSize(control, size)
@@ -408,10 +418,11 @@ function LAMCreateControl.iconpicker(parent, iconpickerData, controlName)
     mungeOverlay:SetAddressMode(TEX_MODE_WRAP)
     mungeOverlay:SetAnchorFill()
 
-    if iconpickerData.warning then
+    if iconpickerData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, control.container, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(iconpickerData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.UpdateChoices = UpdateChoices

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/panel.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/panel.lua
@@ -31,6 +31,9 @@ local function RefreshPanel(control)
         if updateControl.UpdateDisabled then
             updateControl:UpdateDisabled()
         end
+        if updateControl.UpdateWarning then
+            updateControl:UpdateWarning()
+        end
     end
 end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -74,6 +74,16 @@ local function UpdateValue(control, forceDefault, value)
     control.slidervalue:SetText(value)
 end
 
+local function UpdateWarning(control)
+    local warning = LAM.util.GetStringFromValue(control.data.warning)
+    if not warning then
+        control.warning:SetHidden(true)
+    else
+        control.warning.data = {tooltipText = warning}
+        control.warning:SetHidden(false)
+    end
+end
+
 function LAMCreateControl.slider(parent, sliderData, controlName)
     local control = LAM.util.CreateLabelAndContainerControl(parent, sliderData, controlName)
     local isInputOnRight = sliderData.inputLocation == "right" 
@@ -186,10 +196,11 @@ function LAMCreateControl.slider(parent, sliderData, controlName)
         control:UpdateValue(false, new_value)
     end)
 
-    if sliderData.warning then
+    if sliderData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, slider, LEFT, -5, 0)
-        control.warning.data = {tooltipText = LAM.util.GetStringFromValue(sliderData.warning)}
+        control.UpdateWarning = UpdateWarning
+        control:UpdateWarning()
     end
 
     control.UpdateValue = UpdateValue

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -74,16 +74,6 @@ local function UpdateValue(control, forceDefault, value)
     control.slidervalue:SetText(value)
 end
 
-local function UpdateWarning(control)
-    local warning = LAM.util.GetStringFromValue(control.data.warning)
-    if not warning then
-        control.warning:SetHidden(true)
-    else
-        control.warning.data = {tooltipText = warning}
-        control.warning:SetHidden(false)
-    end
-end
-
 function LAMCreateControl.slider(parent, sliderData, controlName)
     local control = LAM.util.CreateLabelAndContainerControl(parent, sliderData, controlName)
     local isInputOnRight = sliderData.inputLocation == "right" 
@@ -199,7 +189,7 @@ function LAMCreateControl.slider(parent, sliderData, controlName)
     if sliderData.warning ~= nil then
         control.warning = wm:CreateControlFromVirtual(nil, control, "ZO_Options_WarningIcon")
         control.warning:SetAnchor(RIGHT, slider, LEFT, -5, 0)
-        control.UpdateWarning = UpdateWarning
+        control.UpdateWarning = LAM.util.UpdateWarning
         control:UpdateWarning()
     end
 


### PR DESCRIPTION
I needed the ability to have the warning icon refresh its tooltip or completely hide (if warning was set to a function that returns nil) during a panel refresh for one of my addons.  So I went ahead and implemented the feature for all widgets that have a warning setting.  Code provided here in case you think it's worth including in the next release.  No offense if you don't want it, though.