### PR TITLE
Debug code and function-type name property

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -713,12 +713,12 @@ local function CreateOptionsControls(panel)
 
                     err, anchorOffset, lastAddedControl, wasHalf = CreateAndAnchorWidget(parent, widgetData, offsetX, anchorOffset, lastAddedControl, wasHalf)
                     if err then
-                        PrintLater(("Could not create %s '%s' of %s."):format(widgetData.type, widgetData.name or "unnamed", addonID))
+                        PrintLater(("Could not create %s '%s' of %s."):format(widgetData.type, GetStringFromValue(widgetData.name or "unnamed"), addonID))
                     end
 
                     if isSubmenu then
                         if SetupCreationCalls(lastAddedControl, widgetData.controls) then
-                            PrintLater(("The sub menu '%s' of %s is missing some entries."):format(widgetData.name or "unnamed", addonID))
+                            PrintLater(("The sub menu '%s' of %s is missing some entries."):format(GetStringFromValue(widgetData.name or "unnamed"), addonID))
                         end
                     end
                 end


### PR DESCRIPTION
Use GetStringFromValue in debug code to avoid errors when the name property is of the function type. Spent quite a bit of time debugging for someone until I discovered this was causing additional problems.