### PR TITLE
add [disabled] to submenu

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
@@ -3,15 +3,35 @@
     name = "Submenu Title", -- or string id or function returning a string
     tooltip = "My submenu tooltip", -- -- or string id or function returning a string (optional)
     controls = {sliderData, buttonData} --(optional) used by LAM
+    disabled = function() return db.someBooleanSetting end, --or boolean (optional)
     reference = "MyAddonSubmenu" --(optional) unique global reference to control
 } ]]
 
-local widgetVersion = 11
+local widgetVersion = 12
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("submenu", widgetVersion) then return end
 
 local wm = WINDOW_MANAGER
 local am = ANIMATION_MANAGER
+
+--label
+local enabledColor = ZO_DEFAULT_ENABLED_COLOR
+local disabledColor = ZO_DEFAULT_DISABLED_COLOR
+
+local function UpdateDisabled(control)
+    local disable
+    if type(control.data.disabled) == "function" then
+        disable = control.data.disabled()
+    else
+        disable = control.data.disabled
+    end
+	
+    if disable then
+        control.label:SetColor(ZO_DEFAULT_DISABLED_COLOR:UnpackRGBA())	
+    else
+        control.label:SetColor(ZO_DEFAULT_ENABLED_COLOR:UnpackRGBA())
+    end
+end
 
 local function UpdateValue(control)
     control.label:SetText(LAM.util.GetStringFromValue(control.data.name))
@@ -101,6 +121,10 @@ function LAMCreateControl.submenu(parent, submenuData, controlName)
     btmToggle:SetHandler("OnMouseUp", AnimateSubmenu)
 
     control.UpdateValue = UpdateValue
+    if submenuData.disabled ~= nil then
+        control.UpdateDisabled = UpdateDisabled
+        control:UpdateDisabled()
+    end
 
     LAM.util.RegisterForRefreshIfNeeded(control)
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
@@ -14,20 +14,19 @@ if not LAM:RegisterWidget("submenu", widgetVersion) then return end
 local wm = WINDOW_MANAGER
 local am = ANIMATION_MANAGER
 
---label
-local enabledColor = ZO_DEFAULT_ENABLED_COLOR
-local disabledColor = ZO_DEFAULT_DISABLED_COLOR
+local function IsDisabled(control)
+    if type(control.data.disabled) == "function" then
+        return control.data.disabled()
+    else
+        return control.data.disabled
+    end
+end
 
 local function UpdateDisabled(control)
-    local disable
-    if type(control.data.disabled) == "function" then
-        disable = control.data.disabled()
-    else
-        disable = control.data.disabled
-    end
-	
-    if disable then
-        control.label:SetColor(ZO_DEFAULT_DISABLED_COLOR:UnpackRGBA())	
+    if IsDisabled(control) then
+        if control.open then
+            control.animation:PlayFromStart()
+        end
     else
         control.label:SetColor(ZO_DEFAULT_ENABLED_COLOR:UnpackRGBA())
     end
@@ -44,10 +43,12 @@ local function AnimateSubmenu(clicked)
     local control = clicked:GetParent()
     control.open = not control.open
 
-    if control.open then
-        control.animation:PlayFromStart()
-    else
-        control.animation:PlayFromEnd()
+    if not IsDisabled(control) then
+        if control.open then
+            control.animation:PlayFromStart()
+        else
+            control.animation:PlayFromEnd()
+        end
     end
 end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
@@ -23,13 +23,22 @@ local function IsDisabled(control)
 end
 
 local function UpdateDisabled(control)
-    if IsDisabled(control) then
+    local disable = IsDisabled(control)
+    if disable == control.disabled then return end
+
+    local color = ZO_DEFAULT_ENABLED_COLOR
+    if disable then
+        color = ZO_DEFAULT_DISABLED_COLOR
+
         if control.open then
+            control.open = false
             control.animation:PlayFromStart()
         end
-    else
-        control.label:SetColor(ZO_DEFAULT_ENABLED_COLOR:UnpackRGBA())
     end
+
+    control.label:SetColor(color:UnpackRGBA())
+    control.arrow:SetColor(color:UnpackRGBA())
+    control.disabled = disable
 end
 
 local function UpdateValue(control)
@@ -41,14 +50,13 @@ end
 
 local function AnimateSubmenu(clicked)
     local control = clicked:GetParent()
-    control.open = not control.open
+    if control.disabled then return end
 
-    if not IsDisabled(control) then
-        if control.open then
-            control.animation:PlayFromStart()
-        else
-            control.animation:PlayFromEnd()
-        end
+    control.open = not control.open
+    if control.open then
+        control.animation:PlayFromStart()
+    else
+        control.animation:PlayFromEnd()
     end
 end
 


### PR DESCRIPTION
This change does:
- add the "disabled" entry to reference a function for disabling the submenu (like other widgets)
- in case "disabled" is true, change the submenu label colour to a greyed out version (and reverse)


This change does NOT:
- disable any child-widgets that belong to the submenu
- prevent the submenu from collapsing/expanding
- close the expanded submenu when it is disabled
