### PR TITLE
add "disabledDesc" for disabling (i.e. greying out) the description text

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -3,7 +3,7 @@
     text = "My description text to display.", -- or string id or function returning a string
     title = "My Title", -- or string id or function returning a string (optional)
     width = "full", --or "half" (optional)
-    disabledDesc = function() return db.someBooleanSetting end, --or boolean (optional)
+    disabled = function() return db.someBooleanSetting end, --or boolean (optional)
     reference = "MyAddonDescription" -- unique global reference to control (optional)
 } ]]
 
@@ -14,24 +14,15 @@ if not LAM:RegisterWidget("description", widgetVersion) then return end
 
 local wm = WINDOW_MANAGER
 
-local function GetResultFromValueOrFunction(value)
-    if type(value) == "function" then
-        return value()
-    else
-        return value
-    end
-end
-
-local function GetColorForState(disabled)
-    return disabled and ZO_DEFAULT_DISABLED_COLOR or ZO_DEFAULT_ENABLED_COLOR
-end
+local GetDefaultValue = LAM.util.GetDefaultValue
+local GetColorForState = LAM.util.GetColorForState
 
 local function UpdateDisabled(control)
-    local disableDesc = GetResultFromValueOrFunction(control.data.disabledDesc)
-    if disableDesc ~= control.disabledDesc then
-        local color = GetColorForState(disableDesc)
+    local disable = GetDefaultValue(control.data.disabled)
+    if disable ~= control.disabled then
+        local color = GetColorForState(disable)
         control.desc:SetColor(color:UnpackRGBA())
-        control.disabledDesc = disableDesc
+        control.disabled = disable
     end
 end
 
@@ -74,7 +65,7 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
     end
 
     control.UpdateValue = UpdateValue
-    if descriptionData.disabledDesc ~= nil then
+    if descriptionData.disabled ~= nil then
         control.UpdateDisabled = UpdateDisabled
         control:UpdateDisabled()
     end


### PR DESCRIPTION
Similar to the new "disabledLabel" for the submenu, the "disabledDesc" can change the font-color of a description and disable it.

Default (either w/o disabledLabel, or disabledLabel is returning false)
![image](https://user-images.githubusercontent.com/14639044/56385464-794b5880-621f-11e9-9a51-d6402528742a.png)

Disabled (disabledLabel returning true)
![image](https://user-images.githubusercontent.com/14639044/56385488-8405ed80-621f-11e9-9eb8-9c548c7ddc83.png)
