### PR TITLE
New "enableLinks" option for description widget

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -76,13 +76,11 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
     if descriptionData.enableLinks then
         desc:SetMouseEnabled(true)
         desc:SetLinkEnabled(true)
-        local linkClickedHandler
         if type(descriptionData.enableLinks) == "function" then
-            linkClickedHandler = descriptionData.enableLinks
+            desc:SetHandler("OnLinkClicked", descriptionData.enableLinks)
         else
-            linkClickedHandler = OnLinkClicked
+            desc:SetHandler("OnLinkClicked", OnLinkClicked)
         end
-        desc:SetHandler("OnLinkClicked", linkClickedHandler)
     end
 
     control.UpdateValue = UpdateValue

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -19,6 +19,10 @@ local wm = WINDOW_MANAGER
 local GetDefaultValue = LAM.util.GetDefaultValue
 local GetColorForState = LAM.util.GetColorForState
 
+local function OnLinkClicked(control, linkData, linkText, button)
+    ZO_LinkHandler_OnLinkClicked(linkText, button) 
+end
+
 local function UpdateDisabled(control)
     local disable = GetDefaultValue(control.data.disabled)
     if disable ~= control.disabled then
@@ -72,14 +76,13 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
     if descriptionData.enableLinks then
         desc:SetMouseEnabled(true)
         desc:SetLinkEnabled(true)
+        local linkClickedHandler
         if type(descriptionData.enableLinks) == "function" then
-            desc.linkClickedHandler = descriptionData.enableLinks
+            linkClickedHandler = descriptionData.enableLinks
         else
-            function desc:linkClickedHandler(linkData, linkText, button)
-                ZO_LinkHandler_OnLinkClicked(linkText, button) 
-            end
+            linkClickedHandler = OnLinkClicked
         end
-        desc:SetHandler("OnLinkClicked", desc.linkClickedHandler)
+        desc:SetHandler("OnLinkClicked", linkClickedHandler)
     end
 
     control.UpdateValue = UpdateValue

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -4,11 +4,13 @@
     title = "My Title", -- or string id or function returning a string (optional)
     width = "full", -- or "half" (optional)
     disabled = function() return db.someBooleanSetting end, -- or boolean (optional)
+    enableLinks = nil, -- or true for default tooltips, or function OnLinkClicked handler (optional)
+                       -- see: https://wiki.esoui.com/UI_XML#OnLinkClicked
     reference = "MyAddonDescription" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 9
+local widgetVersion = 10
 local LAM = LibStub("LibAddonMenu-2.0")
 if not LAM:RegisterWidget("description", widgetVersion) then return end
 
@@ -65,6 +67,19 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
         desc:SetAnchor(TOPLEFT, title, BOTTOMLEFT)
     else
         desc:SetAnchor(TOPLEFT)
+    end
+    
+    if descriptionData.enableLinks then
+        desc:SetMouseEnabled(true)
+        desc:SetLinkEnabled(true)
+        if type(descriptionData.enableLinks) == "function" then
+            desc.linkClickedHandler = descriptionData.enableLinks
+        else
+            function desc:linkClickedHandler(linkData, linkText, button)
+                ZO_LinkHandler_OnLinkClicked(linkText, button) 
+            end
+        end
+        desc:SetHandler("OnLinkClicked", desc.linkClickedHandler)
     end
 
     control.UpdateValue = UpdateValue


### PR DESCRIPTION
Three possible values allowed:

- `nil` (default): links are disabled
- `true`: links clicks will call `ZO_LinkHandler_OnLinkClicked(linktext, button)`
- `function(labelControl, linkData, linkText, button, ctrl, alt, shift, command) end`: the custom function passed will be called upon link click.