### PR TITLE
Added FAQ / helpURL at widgets

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -194,9 +194,10 @@ local function CreateLabelAndContainerControl(parent, controlData, controlName)
 
     if faqTexture then
         faqTexture:ClearAnchors()
-        faqTexture:SetAnchor(LEFT, label, RIGHT, 5, 0)
+        faqTexture:SetAnchor(LEFT, label, RIGHT, 5, -1)
         faqTexture:SetParent(labelContainer)
         label:SetAnchor(LEFT, labelContainer, LEFT)
+        label:SetDimensionConstraints(0, 0, labelContainer:GetWidth() - faqTexture:GetWidth(), 0)
     end
 
     control.data.tooltipText = GetStringFromValue(control.data.tooltip)

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -37,6 +37,9 @@ end
 local logger
 if LibDebugLogger then
     logger = LibDebugLogger(MAJOR)
+else
+    local function noop() end
+    logger = setmetatable({}, { __index = function() return noop end })
 end
 
 if LAMSettingsPanelCreated and not LAMCompatibilityWarning then
@@ -86,8 +89,59 @@ local function GetStringFromValue(value)
     return value
 end
 
+local FAQ_ICON_COLOR = ZO_ColorDef:New("FFFFFF") -- white
+local FAQ_ICON_MOUSE_OVER_COLOR = ZO_ColorDef:New("B8B8D3") -- dark-blue/white
+local FAQ_ICON_MOUSE_OVER_ALPHA = 1
+local FAQ_ICON_MOUSE_EXIT_ALPHA = 0.4
+local FAQ_ICON_SIZE = 23
+local FAQ_ICON_TOOTIP_TEMPLATE = "%s: %s"
+
 local function GetColorForState(disabled)
     return disabled and ZO_DEFAULT_DISABLED_COLOR or ZO_DEFAULT_ENABLED_COLOR
+end
+
+local function CreateFAQTexture(control)
+    local controlData = control.data
+    if not control or not controlData then logger:Warn("CreateFAQTexture - missing or invalid control") return end
+    local helpUrl = controlData and GetStringFromValue(controlData.helpUrl)
+    if not helpUrl or helpUrl == "" then return end
+
+    local faqControl = wm:CreateControl(nil, control, CT_TEXTURE)
+    control.faqControl = faqControl
+
+    faqControl:SetDrawLayer(DL_OVERLAY)
+    faqControl:SetTexture("EsoUI\\Art\\miscellaneous\\help_icon.dds")
+    faqControl:SetDimensions(FAQ_ICON_SIZE, FAQ_ICON_SIZE)
+    faqControl:SetColor(FAQ_ICON_COLOR:UnpackRGBA())
+    faqControl:SetAlpha(FAQ_ICON_MOUSE_EXIT_ALPHA)
+    faqControl:SetHidden(false)
+
+    faqControl.data = faqControl.data or {}
+    faqControl.data.helpUrl = helpUrl
+    faqControl.data.tooltipText = FAQ_ICON_TOOTIP_TEMPLATE:format(util.L.WEBSITE, helpUrl)
+
+    faqControl:SetMouseEnabled(true)
+    local function onMouseExitFAQ(ctrl)
+        ZO_Options_OnMouseExit(ctrl)
+        ctrl:SetColor(FAQ_ICON_COLOR:UnpackRGBA())
+        ctrl:SetAlpha(FAQ_ICON_MOUSE_EXIT_ALPHA)
+    end
+    faqControl:SetHandler("OnMouseUp", function(self, button, upInside)
+        if button == MOUSE_BUTTON_INDEX_LEFT and upInside then
+            --As the parent control's OnMouseExit won't be called because of the popup "open website":
+            --We hide the faq texture ourself
+            onMouseExitFAQ(self, true)
+            RequestOpenUnsafeURL(helpUrl)
+        end
+    end)
+    faqControl:SetHandler("OnMouseEnter", function(self)
+        ZO_Options_OnMouseEnter(self)
+        self:SetColor(FAQ_ICON_MOUSE_OVER_COLOR:UnpackRGBA()) --light blue
+        self:SetAlpha(FAQ_ICON_MOUSE_OVER_ALPHA)
+    end, "LAM2_FAQTexture_OnMouseEnter")
+    faqControl:SetHandler("OnMouseExit", onMouseExitFAQ, "LAM2_FAQTexture_OnMouseExit")
+
+    return faqControl
 end
 
 local function CreateBaseControl(parent, controlData, controlName)
@@ -110,23 +164,39 @@ local function CreateLabelAndContainerControl(parent, controlData, controlName)
     container:SetDimensions(width / 3, MIN_HEIGHT)
     control.container = container
 
-    local label = wm:CreateControl(nil, control, CT_LABEL)
+    local labelContainer
+    local faqTexture = CreateFAQTexture(control)
+    if faqTexture then
+        labelContainer = wm:CreateControl(nil, control, CT_CONTROL)
+        labelContainer:SetHeight(MIN_HEIGHT)
+        control.labelContainer = container
+    end
+
+    local label = wm:CreateControl(nil, labelContainer or control, CT_LABEL)
     label:SetFont("ZoFontWinH4")
     label:SetHeight(MIN_HEIGHT)
     label:SetWrapMode(TEXT_WRAP_MODE_ELLIPSIS)
     label:SetText(GetStringFromValue(controlData.name))
     control.label = label
 
+    local labelAnchorTarget = labelContainer or label
     if control.isHalfWidth then
         control:SetDimensions(width / 2, MIN_HEIGHT * 2 + HALF_WIDTH_LINE_SPACING)
-        label:SetAnchor(TOPLEFT, control, TOPLEFT, 0, 0)
-        label:SetAnchor(TOPRIGHT, control, TOPRIGHT, 0, 0)
-        container:SetAnchor(TOPRIGHT, control.label, BOTTOMRIGHT, 0, HALF_WIDTH_LINE_SPACING)
+        labelAnchorTarget:SetAnchor(TOPLEFT, control, TOPLEFT, 0, 0)
+        labelAnchorTarget:SetAnchor(TOPRIGHT, control, TOPRIGHT, 0, 0)
+        container:SetAnchor(TOPRIGHT, labelAnchorTarget, BOTTOMRIGHT, 0, HALF_WIDTH_LINE_SPACING)
     else
         control:SetDimensions(width, MIN_HEIGHT)
         container:SetAnchor(TOPRIGHT, control, TOPRIGHT, 0, 0)
-        label:SetAnchor(TOPLEFT, control, TOPLEFT, 0, 0)
-        label:SetAnchor(TOPRIGHT, container, TOPLEFT, 5, 0)
+        labelAnchorTarget:SetAnchor(TOPLEFT, control, TOPLEFT, 0, 0)
+        labelAnchorTarget:SetAnchor(TOPRIGHT, container, TOPLEFT, 5, 0)
+    end
+
+    if faqTexture then
+        faqTexture:ClearAnchors()
+        faqTexture:SetAnchor(LEFT, label, RIGHT, 5, 0)
+        faqTexture:SetParent(labelContainer)
+        label:SetAnchor(LEFT, labelContainer, LEFT)
     end
 
     control.data.tooltipText = GetStringFromValue(control.data.tooltip)
@@ -505,6 +575,7 @@ util.RegisterForReloadIfNeeded = RegisterForReloadIfNeeded
 util.GetTopPanel = GetTopPanel
 util.ShowConfirmationDialog = ShowConfirmationDialog
 util.UpdateWarning = UpdateWarning
+util.CreateFAQTexture = CreateFAQTexture
 
 local ADDON_DATA_TYPE = 1
 local RESELECTING_DURING_REBUILD = true
@@ -836,9 +907,7 @@ local function CreateOptionsControls(panel)
                     err, anchorOffset, lastAddedControl, wasHalf = CreateAndAnchorWidget(parent, widgetData, offsetX, anchorOffset, lastAddedControl, wasHalf)
                     if err then
                         PrintLater(("Could not create %s '%s' of %s."):format(widgetData.type, GetStringFromValue(widgetData.name or "unnamed"), addonID))
-                        if logger then
-                            logger:Error(err)
-                        end
+                        logger:Error(err)
                     end
 
                     if isSubmenu then
@@ -907,9 +976,7 @@ local function ShowSetHandlerWarning(panel, handler)
     if hint then
         local message = ("Setting a handler on a panel is not recommended. Use the global callback %s instead. (%s on %s)"):format(hint, handler, panel.data.name)
         PrintLater(message)
-        if logger then
-            logger:Warn(message)
-        end
+        logger:Warn(message)
     end
 end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/button.lua
@@ -8,10 +8,11 @@
     icon = "icon\\path.dds", -- (optional)
     isDangerous = false, -- boolean, if set to true, the button text will be red and a confirmation dialog with the button label and warning text will show on click before the callback is executed (optional)
     warning = "Will need to reload the UI.", -- (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonButton", -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 11
+local widgetVersion = 12
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("button", widgetVersion) then return end
 
@@ -83,6 +84,12 @@ function LAMCreateControl.button(parent, buttonData, controlName)
     if buttonData.disabled ~= nil then
         control.UpdateDisabled = UpdateDisabled
         control:UpdateDisabled()
+    end
+
+    local faqTexture = LAM.util.CreateFAQTexture(control)
+    if faqTexture then
+        faqTexture:ClearAnchors()
+        faqTexture:SetAnchor(LEFT, button, RIGHT, 0, 0)
     end
 
     LAM.util.RegisterForRefreshIfNeeded(control)

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/checkbox.lua
@@ -9,11 +9,12 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = defaults.var, -- a boolean or function that returns a boolean (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonCheckbox", -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 14
+local widgetVersion = 15
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("checkbox", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/colorpicker.lua
@@ -9,11 +9,12 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = {r = defaults.r, g = defaults.g, b = defaults.b, a = defaults.a}, -- (optional) table of default color values (or default = defaultColor, where defaultColor is a table with keys of r, g, b[, a]) or a function that returns the color
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonColorpicker" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 14
+local widgetVersion = 15
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("colorpicker", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/description.lua
@@ -6,11 +6,12 @@
     disabled = function() return db.someBooleanSetting end, -- or boolean (optional)
     enableLinks = nil, -- or true for default tooltips, or function OnLinkClicked handler (optional)
                        -- see: https://wiki.esoui.com/UI_XML#OnLinkClicked
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonDescription" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 10
+local widgetVersion = 11
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("description", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/dropdown.lua
@@ -14,11 +14,12 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = defaults.var, -- default value or function that returns the default value (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonDropdown" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 20
+local widgetVersion = 21
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("dropdown", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/editbox.lua
@@ -13,11 +13,12 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = defaults.text, -- default value or function that returns the default value (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonEditbox" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 15
+local widgetVersion = 16
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("editbox", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/header.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/header.lua
@@ -2,11 +2,12 @@
     type = "header",
     name = "My Header", -- or string id or function returning a string
     width = "full", -- or "half" (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonHeader" -- unique global reference to control (optional)
 } ]]
 
 
-local widgetVersion = 8
+local widgetVersion = 9
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("header", widgetVersion) then return end
 
@@ -33,6 +34,11 @@ function LAMCreateControl.header(parent, headerData, controlName)
     header:SetAnchor(TOPLEFT, divider, BOTTOMLEFT)
     header:SetAnchor(BOTTOMRIGHT)
     header:SetText(LAM.util.GetStringFromValue(headerData.name))
+
+    local faqTexture = LAM.util.CreateFAQTexture(control)
+    if faqTexture then
+        faqTexture:SetAnchor(RIGHT, header, RIGHT, 0, 0)
+    end
 
     control.UpdateValue = UpdateValue
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/iconpicker.lua
@@ -16,10 +16,11 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = defaults.var, -- default value or function that returns the default value (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonIconPicker" -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 9
+local widgetVersion = 10
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("iconpicker", widgetVersion) then return end
 

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/slider.lua
@@ -18,10 +18,11 @@
     warning = "May cause permanent awesomeness.", -- or string id or function returning a string (optional)
     requiresReload = false, -- boolean, if set to true, the warning text will contain a notice that changes are only applied after an UI reload and any change to the value will make the "Apply Settings" button appear on the panel which will reload the UI when pressed (optional)
     default = defaults.var, -- default value or function that returns the default value (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonSlider" -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 14
+local widgetVersion = 15
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("slider", widgetVersion) then return end
 
@@ -111,7 +112,7 @@ function LAMCreateControl.slider(parent, sliderData, controlName)
     bg:SetCenterColor(0, 0, 0)
     bg:SetAnchor(TOPLEFT, slider, TOPLEFT, 0, 4)
     bg:SetAnchor(BOTTOMRIGHT, slider, BOTTOMRIGHT, 0, -4)
-    bg:SetEdgeTexture("EsoUI\\Art\\Tooltips\\UI-SliderBackdrop.dds", 32, 4) 
+    bg:SetEdgeTexture("EsoUI\\Art\\Tooltips\\UI-SliderBackdrop.dds", 32, 4)
 
     control.minText = wm:CreateControl(nil, slider, CT_LABEL)
     local minText = control.minText

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0/controls/submenu.lua
@@ -7,10 +7,11 @@
     controls = {sliderData, buttonData} -- used by LAM (optional)
     disabled = function() return db.someBooleanSetting end, -- or boolean (optional)
     disabledLabel = function() return db.someBooleanSetting end, -- or boolean (optional)
+    helpUrl = "https://www.esoui.com/portal.php?id=218&a=faq", -- a string URL or a function that returns the string URL (optional)
     reference = "MyAddonSubmenu" -- unique global reference to control (optional)
 } ]]
 
-local widgetVersion = 13
+local widgetVersion = 14
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("submenu", widgetVersion) then return end
 
@@ -136,6 +137,11 @@ function LAMCreateControl.submenu(parent, submenuData, controlName)
     arrow:SetDimensions(28, 28)
     arrow:SetTexture("EsoUI\\Art\\Miscellaneous\\list_sortdown.dds") --list_sortup for the other way
     arrow:SetAnchor(TOPRIGHT, bg, TOPRIGHT, -5, 5)
+
+    local faqTexture = LAM.util.CreateFAQTexture(control)
+    if faqTexture then
+        faqTexture:SetAnchor(RIGHT, arrow, LEFT, 0, 0)
+    end
 
     --figure out the cool animation later...
     control.animation = am:CreateTimeline()


### PR DESCRIPTION
[Widget versions were not yet increased! Please do  so if neccessary]
-Added attribute helpUrl to most widgets
-Added functions to LibAddonMenu-2.0.lua to create a FAQ texture (?) control at the widget controls (next right of their label text's width, or if no label is given right of the widget control)
-Hovering the texture will show "Open website: " .. url
-Clicking the texture will open the URL open dialog of ESO