### PR TITLE
Dropdown widget v15 - With multiselect

### DIFF
--- a/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/controls/dropdown.lua
@@ -68,15 +68,32 @@ local function updateMultiSelectSelected(control, values)
     local dropdown = control.dropdown
     dropdown.m_selectedItemData = {}
     if multiSelectType == "normal" then
-        for _, v in ipairs(values) do
+        for k, v in ipairs(values) do
+            --dropdown:SelectItemByIndex(k, true)
             dropdown:SetSelectedItemByEval(function(entry)
-                return entry.dataEntry.data.name == v
+d("[LAM2]dropdown - k: " .. tostring(k) .. ", v: " ..tostring(v) .. ", entry.value: " ..tostring(entry.value) ..", entry.name: " ..tostring(entry.name))
+FCOCS._debugEntry = entry
+FCOCS._debugEntryV = v
+                if entry.value ~= nil then
+                    return entry.value == v
+                else
+                    return entry.name ~= nil and entry.name == v
+                end
             end, true)
         end
     elseif multiSelectType == "allowed" then
         for k, isAllowed in pairs(values) do
             if isAllowed == true then
-                dropdown:SelectItemByIndex(k, true)
+                dropdown:SetSelectedItemByEval(function(entry)
+d("[LAM2]dropdown - k: " .. tostring(k) .. ", entry.value: " ..tostring(entry.value) ..", entry.name: " ..tostring(entry.name))
+    FCOCS._debugEntry = entry
+    FCOCS._debugEntryK = k
+                    if entry.value ~= nil then
+                        return entry.value == k
+                    else
+                        return entry.name ~= nil and entry.name == k
+                    end
+                end, true)
             end
         end
     end


### PR DESCRIPTION
Added multiselection possibilities to the dropdown widget.
-> if multiselection is enabled the getFunc and setFunc are working with a table instead of single values!

Should be fully backwards comaptible with old dropdowns.

Widget's data table additions are:
```
    multiSelect = false, -- boolean or function returning a boolean. If set to true you can select multiple entries at the list (optional)
    multiSelectTextFormatter = SI_COMBO_BOX_DEFAULT_MULTISELECTION_TEXT_FORMATTER, -- or string id or function returning a string. If specified, this will be used with zo_strformat(multiSelectTextFormatter, numSelectedItems) to set the "selected item text". Only incombination with multiSelect = true (optional)
    multiSelectNoSelectionText = SI_COMBO_BOX_DEFAULT_NO_SELECTION_TEXT, -- or string id or function returning a string. Only incombination with multiSelect = true (optional)
    multiSelectType = "normal", -- String or function returning a string "normal" or "allowed". "normal" = a list with key = number index and value = String / "allowed" = a list with key = any String or number and value = boolean. If value == true then the entry will be added. Default = "normal". Only incombination with multiSelect = true (optional)
    multiSelectMaxSelections = 5, --Number or function returning a number of the maximum of selectable entries. If not specified there is no max selection. Only incombination with multiSelect = true (optional)
