### PR TITLE
anchor constrains fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Thumbs.db
 /target
 /temp
 /.history
+
+# vscode
+/.vscode

--- a/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -121,7 +121,7 @@ local function CreateFAQTexture(control)
     faqControl.data.tooltipText = FAQ_ICON_TOOTIP_TEMPLATE:format(util.L.WEBSITE, helpUrl)
 
     faqControl:SetMouseEnabled(true)
-    local function onMouseExitFAQ(ctrl)
+    local function onMouseExitFAQ(ctrl, ...)
         ZO_Options_OnMouseExit(ctrl)
         ctrl:SetColor(FAQ_ICON_COLOR:UnpackRGBA())
         ctrl:SetAlpha(FAQ_ICON_MOUSE_EXIT_ALPHA)

--- a/LibAddonMenu-2.0/controls/custom.lua
+++ b/LibAddonMenu-2.0/controls/custom.lua
@@ -9,7 +9,7 @@
     resetFunc = function(customControl) d("defaults reset") end, -- custom function to run after the control is reset to defaults (optional)
 } ]]
 
-local widgetVersion = 8
+local widgetVersion = 9
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("custom", widgetVersion) then return end
 
@@ -31,8 +31,10 @@ function LAMCreateControl.custom(parent, customData, controlName)
 
     if control.isHalfWidth then --note these restrictions
         control:SetDimensionConstraints(width / 2, minHeight, width / 2, maxHeight)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     else
         control:SetDimensionConstraints(width, minHeight, width, maxHeight)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     end
 
     control.UpdateValue = UpdateValue

--- a/LibAddonMenu-2.0/controls/description.lua
+++ b/LibAddonMenu-2.0/controls/description.lua
@@ -13,7 +13,7 @@
 } ]]
 
 
-local widgetVersion = 13
+local widgetVersion = 14
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("description", widgetVersion) then return end
 
@@ -53,8 +53,10 @@ function LAMCreateControl.description(parent, descriptionData, controlName)
 
     if isHalfWidth then
         control:SetDimensionConstraints(width / 2, 0, width / 2, 0)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     else
         control:SetDimensionConstraints(width, 0, width, 0)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     end
 
     control.desc = wm:CreateControl(nil, control, CT_LABEL)

--- a/LibAddonMenu-2.0/controls/texture.lua
+++ b/LibAddonMenu-2.0/controls/texture.lua
@@ -10,7 +10,7 @@
 
 -- TODO: add texture coords support?
 
-local widgetVersion = 10
+local widgetVersion = 11
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("texture", widgetVersion) then return end
 
@@ -24,8 +24,10 @@ function LAMCreateControl.texture(parent, textureData, controlName)
 
     if control.isHalfWidth then --note these restrictions
         control:SetDimensionConstraints(width / 2, MIN_HEIGHT, width / 2, MIN_HEIGHT * 4)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     else
         control:SetDimensionConstraints(width, MIN_HEIGHT, width, MIN_HEIGHT * 4)
+        control:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_Y)
     end
 
     control.texture = wm:CreateControl(nil, control, CT_TEXTURE)


### PR DESCRIPTION
fixes blank log lines like this.

```
2023-12-29T14:49:44.685-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.128-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:45.996-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:46.096-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r
2023-12-29T14:49:46.193-06:00 |cff0000Gui Warning:  has a set width but has resizeToFitDescendents enabled. If this is intended, use resizeToFitConstrains="Y".|r

```