### PR TITLE
Fix multi-select dropdowns flip-flopping between empty and not

### DIFF
--- a/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/controls/dropdown.lua
@@ -76,6 +76,7 @@ local function UpdateMultiSelectSelected(control, values)
 
     local dropdown = control.dropdown
     dropdown.m_selectedItemData = {}
+    dropdown.m_multiSelectItemData = {}
 
     local choicesValues = data.choicesValues
     local usesChoicesValues = choicesValues ~= nil


### PR DESCRIPTION
https://github.com/Baertram/ESO-LibAddonMenu/blob/master/LibAddonMenu-2.0/controls/dropdown.lua#L73-L97 currently only clears dropdown.m_selectedItemData, but m_enableMultiSelect dropdowns use m_multiSelectItemData instead. Because that isn't cleared, dropdown:SetSelectedItemByEval resolves eventually into SelectItem (which, in /EsoUI/Libraries/ZO_ComboBox/ZO_ComboBox.lua:341, self:RemoveItemFromSelected(item) if the item was already self:IsItemSelected(item) ). So ultimately, UpdateMultiSelectSelected currently untoggles everything when called (for multiSelect only).
This fixes that by clearing m_multiSelectItemData also.

For clarification, the repro steps:
1. Have any multi-select dropdowns with elements selected in them
2. Do anything to any other control in the same panel while watching the summary text on the multiselects
3. Watch the multiselects flip between e.g. 3 selected and none selected (at least visually)