### PR TITLE
Add maxChars to HAS conversion

### DIFF
--- a/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
+++ b/LibAddonMenu-2.0/LibAddonMenu-2.0.lua
@@ -1569,6 +1569,7 @@ function lam:convertLamOptionsToHasTable(optionsTable, controlTable)
                 disable = entry.disabled,
                 clickHandler = entry.func,
                 buttonText = entry.name,
+                maxChars = entry.maxChars,
             }
             addToControlTable(newOption, controlTable)
             -- settings:AddSetting(newOption)


### PR DESCRIPTION
The ST_EDIT control for HAS supports a maxChars param, which is also present in LAM's editbox, so this PR is just adding the param to the conversion list.