### PR TITLE
Update dropdown.lua - Add DimensionContrain update for X and Y (default is only Y all of sudden)

### DIFF
--- a/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/controls/dropdown.lua
@@ -24,7 +24,7 @@
 } ]]
 
 
-local widgetVersion = 27
+local widgetVersion = 28
 local LAM = LibAddonMenu2
 if not LAM:RegisterWidget("dropdown", widgetVersion) then return end
 
@@ -329,6 +329,7 @@ local function AdjustDimensions(control, dropdown, dropdownData)
     end
 
     local width = zo_max(contentWidth, dropdown.m_container:GetWidth())
+    dropdownObject:SetResizeToFitConstrains(ANCHOR_CONSTRAINS_XY)
     dropdownObject:SetWidth(width)
 
     scrollContent:SetAnchor(BOTTOMRIGHT, nil, nil, anchorOffset)


### PR DESCRIPTION
Update dropdown.lua - Add DimensionContrain update to fix width of dropdown getting set to proper calculated with, instead of staying at default ANCHOR_CONSTRAINS_Y only