### PR TITLE
Fix multiSelect dropdown to use value, not index

### DIFF
--- a/LibAddonMenu-2.0/controls/dropdown.lua
+++ b/LibAddonMenu-2.0/controls/dropdown.lua
@@ -76,11 +76,7 @@ local function UpdateMultiSelectSelected(control, values)
     local choicesValues = data.choicesValues
     local usesChoicesValues = choicesValues ~= nil
 
-    for _, v in ipairs(values) do
-        local toCompare = v
-        if usesChoicesValues then
-            toCompare = choicesValues[v]
-        end
+    for _, toCompare in ipairs(values) do
         dropdown:SetSelectedItemByEval(function(entry)
             if usesChoicesValues then
                 return entry.value == toCompare


### PR DESCRIPTION
This should fix #156 

Before this change, if a multiSelect dropdown has choicesValues, the getFunc only works with indices of the selected items. Since the table that getFunc should return is meant to be a contiguous table of the values that should be selected, we should set the dropdown with the value itself, where the only difference in useChoicesValues is for whether we match against the item's value or name.